### PR TITLE
21 viewing past orders

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,8 @@
 q!
+session[:user_id]
+Order.all
+params
+q!
 params[:session][:username]
 params[:session]
 q!

--- a/.byebug_history
+++ b/.byebug_history
@@ -1,3 +1,16 @@
+q!
+params[:session][:username]
+params[:session]
+q!
+User.find_by(username: params[:session][:username])
+session[:user_id]
+session
+params
+q!
+User.find("1")
+params[:id]
+User.find(1)
+params
 c
 q!
 session[:cart]

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,7 +5,11 @@ class OrdersController < ApplicationController
     session[:cart].each do |tool_id, quantity|
       OrderTool.create(tool_id: tool_id, quantity: quantity, order_id: @order.id)
     end
-    render :index
+    render :show
+  end
+
+  def index
+    @orders = Order.where(user_id: session[:user_id])
   end
 
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,13 +14,14 @@ class SessionsController < ApplicationController
   end
 
   def create
+    # byebug
      @user = User.find_by(username: params[:session][:username])
      if @user && @user.authenticate(params[:session][:password])
        session[:user_id] = @user.id
        if params[:user_action] == "checkout"
          redirect_to cart_path
        else
-         redirect_to @user
+         redirect_to dashboard_path(@user.id)
        end
      else
        flash.now[:error] = 'Invalid email/password combination'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    # byebug
     @user = User.find(params[:id])
   end
 

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,3 +1,5 @@
-<h1>"Order was successfully placed"</h1>
+<h1>Order Table</h1>
 
-Order <%= @order.id %>
+<% @orders.each do |order| %>
+  Order <%= order.id %>
+<% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,0 +1,3 @@
+<h1>"Order was successfully placed"</h1>
+
+Order <%= @order.id %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,3 +5,7 @@
 <div class="user-info">
   User Information: <%= @user.username %>
 </div>
+
+<div>
+  <%= link_to "View Past Orders", "/orders" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get "/login", to: "sessions#new", as: :login
   post "/login", to: "sessions#create", as: :session_users
   get "/cart/login", to: "sessions#cart_login", as: :cart_login
+  get "/orders", to: "orders#index", as: :orders_index
   post "/orders", to: "orders#create", as: :orders
 
   resources :tools, only: [:index, :show]

--- a/db/migrate/20160423171023_add_user_to_orders.rb
+++ b/db/migrate/20160423171023_add_user_to_orders.rb
@@ -1,0 +1,5 @@
+class AddUserToOrders < ActiveRecord::Migration
+  def change
+    add_reference :orders, :user, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160423011501) do
+ActiveRecord::Schema.define(version: 20160423171023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,10 @@ ActiveRecord::Schema.define(version: 20160423011501) do
   create_table "orders", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "user_id"
   end
+
+  add_index "orders", ["user_id"], name: "index_orders_on_user_id", using: :btree
 
   create_table "tools", force: :cascade do |t|
     t.string   "name"
@@ -71,5 +74,6 @@ ActiveRecord::Schema.define(version: 20160423011501) do
   add_foreign_key "cart_tools", "tools"
   add_foreign_key "order_tools", "orders"
   add_foreign_key "order_tools", "tools"
+  add_foreign_key "orders", "users"
   add_foreign_key "tools", "categories"
 end

--- a/spec/factories/order_tools.rb
+++ b/spec/factories/order_tools.rb
@@ -1,7 +1,14 @@
 FactoryGirl.define do
   factory :order_tool do
-    tool nil
-    order nil
+    tool
+    order
     quantity 1
   end
 end
+
+
+# user = create(:user)
+# tool1 = create(:tool, :name = "tool1")
+# tool2 = create(:tool, :name = "tool2")
+# order1 = Order.create(:user_id = user.id)
+# order2 = Order.create(:user_id = user.id)

--- a/spec/features/user_can_view_past_orders_spec.rb
+++ b/spec/features/user_can_view_past_orders_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature "User can view past orders" do
+  scenario "user has multiple past orders" do
+    # Background: An existing user that has multiple orders
+    user1 = create(:user)
+    user2 = create(:user)
+    tool1 = create(:tool, name: "tool1")
+    tool2 = create(:tool, name: "tool2")
+    order1 = Order.create(user_id: user1.id)
+    order2 = Order.create(user_id: user1.id)
+    order_tool1 = create(:order_tool, tool: tool1, quantity: 3, order: order1)
+    order_tool2 = create(:order_tool, tool: tool2, quantity: 1, order: order1)
+    order_tool3 = create(:order_tool, tool: tool1, quantity: 5, order: order2)
+
+    order3 = Order.create(user_id: user2.id)
+    order_tool4 = create(:order_tool, tool: tool2, quantity: 7, order: order3)
+
+    #   As an Authenticated User
+    visit login_path
+    fill_in "Username", with: user1.username
+    fill_in "Password", with: user1.password
+    click_on "Login"
+
+    assert_equal dashboard_path, current_path
+    click_on "View Past Orders"
+    #   When I visit "/orders"
+    #   Then I should see all orders belonging to me and no other orders
+    assert_equal "/orders", current_path
+    expect(page).to have_content "Order #{order1.id}"
+    expect(page).to have_content "Order #{order2.id}"
+    assert_equal 3, Order.count
+    expect(page).to have_no_content "Order #{order3.id}"
+  end
+end

--- a/spec/features/user_can_view_past_orders_spec.rb
+++ b/spec/features/user_can_view_past_orders_spec.rb
@@ -20,9 +20,13 @@ RSpec.feature "User can view past orders" do
     visit login_path
     fill_in "Username", with: user1.username
     fill_in "Password", with: user1.password
-    click_on "Login"
+    # save_and_open_page
+    within(".login") do
+      click_on "Login"
+    end
 
-    assert_equal dashboard_path, current_path
+    assert_equal dashboard_path(user1.id), current_path
+    # save_and_open_page
     click_on "View Past Orders"
     #   When I visit "/orders"
     #   Then I should see all orders belonging to me and no other orders


### PR DESCRIPTION
Implement user is able to view past orders. From waffle card #21. Logged in user can view their past orders, but not those of other users. Add `user_id` as foreign key in the Orders table. Passing test for view past orders.