### PR TITLE
Send admin to admin_dashboard_path

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,9 @@ class UsersController < ApplicationController
   end
 
   def show
-    if current_user
+    if current_admin?
+      redirect_to admin_dashboard_path
+    elsif current_user
       @user = current_user
     else
       redirect_to login_path
@@ -35,14 +37,16 @@ class UsersController < ApplicationController
     @user = current_user
     @user.update(user_params)
     if @user.save
-      redirect_to dashboard_path
+      if current_admin?
+        redirect_to admin_dashboard_path
+      else
+        redirect_to dashboard_path
+      end
     else
       flash[:error] = "An error occurred. Please try again."
       render :edit
     end
   end
-
-
 
   private
 

--- a/spec/features/admin_can_only_update_itself_spec.rb
+++ b/spec/features/admin_can_only_update_itself_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Admin logged in" do
     fill_in "Password", with: "more nonsense"
     click_on "Update My Account"
 
-    assert_equal user_path(admin), current_path
+    assert_equal admin_dashboard_path, current_path
     expect(User.find(admin.id).username).to eql(new_username)
   end
 

--- a/spec/features/admin_redirects_to_admin_dashboard_spec.rb
+++ b/spec/features/admin_redirects_to_admin_dashboard_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.feature "Admin logged in" do
+  include SpecTestHelper
+
+  scenario "redirects to admin dashboard" do
+    admin = create(:user, role: 1)
+    # after updating himself
+    # clicking on "My Dashboard" ever
+    login_user(admin)
+    new_username = "nonsense"
+    new_password = "more nonsense"
+    login_user(admin)
+    click_on "Update My Account"
+    fill_in "Username", with: "nonsense"
+    fill_in "Password", with: "more nonsense"
+    click_on "Update My Account"
+
+    assert_equal admin_dashboard_path, current_path
+
+    visit root_path
+    click_on "My Dashboard"
+
+    assert_equal admin_dashboard_path, current_path
+  end
+end

--- a/spec/features/guest_must_login_to_checkout_spec.rb
+++ b/spec/features/guest_must_login_to_checkout_spec.rb
@@ -37,11 +37,9 @@ RSpec.feature "Guest user must login before checking out" do
     expect(page).to have_content @tools[1].name
     expect(page).to have_content @tools[2].name
     expect(page).to have_content "Total: $#{total_price}"
-    
+
     click_on "Logout"
     expect(page).to have_no_content "Logout"
     expect(page).to have_content "Login"
-
-
   end
 end


### PR DESCRIPTION
This commit changes the `show` and `update` methods in the UsersController. It
inserts conditionals into both of these methods so that if the requesting
user is an admin, the user is taken to the admin_dashboard_path when redirected
instead of to the user dashboard view.

Getting all the tests to pass meant changing an assertion in a previous test so
that this improved flow would be accounted for in that test.